### PR TITLE
Implement category-based news refinement chat

### DIFF
--- a/client/src/components/dashboard/category-chat-modal.tsx
+++ b/client/src/components/dashboard/category-chat-modal.tsx
@@ -1,0 +1,288 @@
+import { useState, useRef, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { X, Send, MessageSquare, Search } from "lucide-react";
+
+interface CategoryChatModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  category: string;
+  categoryName: string;
+  categoryIcon: string;
+  categoryColor: string;
+  sessionId: string;
+}
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: Date;
+  newsItems?: any[];
+}
+
+interface CategoryChatResponse {
+  success: boolean;
+  response: string;
+  news_items: any[];
+  queries_used: string[];
+  error?: string;
+}
+
+export function CategoryChatModal({
+  isOpen,
+  onClose,
+  category,
+  categoryName,
+  categoryIcon,
+  categoryColor,
+  sessionId
+}: CategoryChatModalProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputMessage, setInputMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-resize textarea
+  const autoResize = () => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = Math.min(textareaRef.current.scrollHeight, 120) + 'px';
+    }
+  };
+
+  // Scroll to bottom when new messages arrive
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  // Handle sending message
+  const handleSendMessage = async () => {
+    if (!inputMessage.trim() || isSending) return;
+
+    const userMessage = inputMessage.trim();
+    const messageId = `msg-${Date.now()}`;
+
+    // Add user message immediately
+    const newUserMessage: ChatMessage = {
+      id: messageId,
+      role: 'user',
+      content: userMessage,
+      timestamp: new Date()
+    };
+
+    setMessages(prev => [...prev, newUserMessage]);
+    setInputMessage("");
+    setIsSending(true);
+
+    try {
+      const response = await fetch(`/api/chat/category/${category}/send`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          session_id: sessionId,
+          message: userMessage
+        }),
+      });
+
+      const result: CategoryChatResponse = await response.json();
+
+      if (result.success) {
+        // Add assistant response
+        const assistantMessage: ChatMessage = {
+          id: `assistant-${Date.now()}`,
+          role: 'assistant',
+          content: result.response,
+          timestamp: new Date(),
+          newsItems: result.news_items
+        };
+
+        setMessages(prev => [...prev, assistantMessage]);
+      } else {
+        // Add error message
+        const errorMessage: ChatMessage = {
+          id: `error-${Date.now()}`,
+          role: 'assistant',
+          content: `Sorry, I encountered an error: ${result.error || 'Unknown error'}`,
+          timestamp: new Date()
+        };
+
+        setMessages(prev => [...prev, errorMessage]);
+      }
+    } catch (error) {
+      console.error('Error sending message:', error);
+      const errorMessage: ChatMessage = {
+        id: `error-${Date.now()}`,
+        role: 'assistant',
+        content: 'Sorry, I encountered an error while processing your request. Please try again.',
+        timestamp: new Date()
+      };
+
+      setMessages(prev => [...prev, errorMessage]);
+    } finally {
+      setIsSending(false);
+      if (textareaRef.current) {
+        textareaRef.current.style.height = 'auto';
+      }
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSendMessage();
+    }
+  };
+
+  // Add welcome message when modal opens
+  useEffect(() => {
+    if (isOpen && messages.length === 0) {
+      const welcomeMessage: ChatMessage = {
+        id: 'welcome',
+        role: 'assistant',
+        content: `Welcome to the ${categoryName} chat! I can help you find specific news and information. Try asking me things like:
+        
+• "Show me recent FDA approvals for oncology drugs"
+• "Find clinical trials for diabetes in Europe" 
+• "What's the latest on payer coverage for diabetes medications?"
+• "Get RWE studies for cardiovascular outcomes"
+
+What would you like to know about ${categoryName}?`,
+        timestamp: new Date()
+      };
+      setMessages([welcomeMessage]);
+    }
+  }, [isOpen, categoryName]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <Card className="w-full max-w-4xl h-[80vh] flex flex-col">
+        <CardHeader className="flex-shrink-0 border-b">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <div className={`w-10 h-10 ${categoryColor} rounded-lg flex items-center justify-center`}>
+                <i className={`${categoryIcon} text-white text-lg`}></i>
+              </div>
+              <div>
+                <CardTitle className="text-xl">{categoryName} Chat</CardTitle>
+                <p className="text-sm text-gray-500">Ask me about {categoryName.toLowerCase()} news and updates</p>
+              </div>
+            </div>
+            <Button
+              onClick={onClose}
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </CardHeader>
+
+        <CardContent className="flex-1 flex flex-col p-0">
+          {/* Messages Area */}
+          <div className="flex-1 overflow-y-auto p-6 space-y-4">
+            {messages.map((message) => (
+              <div key={message.id} className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                <div className={`max-w-[80%] ${message.role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-100 dark:bg-gray-800'} rounded-lg px-4 py-3`}>
+                  <div className="whitespace-pre-line">{message.content}</div>
+                  
+                  {/* Show news items if available */}
+                  {message.newsItems && message.newsItems.length > 0 && (
+                    <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+                      <div className="text-sm font-medium mb-2">Found {message.newsItems.length} relevant news items:</div>
+                      <div className="space-y-2">
+                        {message.newsItems.slice(0, 3).map((item, index) => (
+                          <div key={index} className="bg-white dark:bg-gray-700 rounded p-2 text-sm">
+                            <div className="font-medium text-blue-600 dark:text-blue-400">
+                              <a href={item.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                                {item.title}
+                              </a>
+                            </div>
+                            <div className="text-gray-600 dark:text-gray-300 text-xs mt-1">
+                              {item.source} • {item.date}
+                            </div>
+                          </div>
+                        ))}
+                        {message.newsItems.length > 3 && (
+                          <div className="text-xs text-gray-500">
+                            +{message.newsItems.length - 3} more items
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+            
+            {isSending && (
+              <div className="flex justify-start">
+                <div className="bg-gray-100 dark:bg-gray-800 rounded-lg px-4 py-3">
+                  <div className="flex space-x-1">
+                    <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"></div>
+                    <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></div>
+                    <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
+                  </div>
+                </div>
+              </div>
+            )}
+            
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Input Area */}
+          <div className="flex-shrink-0 border-t p-4">
+            <div className="flex items-end space-x-3">
+              <div className="flex-1">
+                <Textarea
+                  ref={textareaRef}
+                  value={inputMessage}
+                  onChange={(e) => {
+                    setInputMessage(e.target.value);
+                    autoResize();
+                  }}
+                  onKeyDown={handleKeyDown}
+                  placeholder={`Ask me about ${categoryName.toLowerCase()} news...`}
+                  className="min-h-[48px] max-h-[120px] resize-none"
+                  disabled={isSending}
+                />
+              </div>
+              <Button
+                onClick={handleSendMessage}
+                disabled={!inputMessage.trim() || isSending}
+                className="bg-blue-600 hover:bg-blue-700 text-white h-[48px] px-4"
+              >
+                {isSending ? (
+                  <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+            <div className="flex items-center justify-between mt-2 text-xs text-gray-500">
+              <span>Press Enter to send, Shift+Enter for new line</span>
+              <div className="flex items-center space-x-1">
+                <Search className="h-3 w-3" />
+                <span>AI-powered search</span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/components/dashboard/heor-dashboard.tsx
+++ b/client/src/components/dashboard/heor-dashboard.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
 import { useNewsAgents, UserPreferences, NewsItem } from "@/hooks/useNewsAgents";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { CategoryChatModal } from "./category-chat-modal";
 import agilLogo from "@assets/Logo Primary_1753368301220.png";
 
 interface DashboardProps {
@@ -174,6 +175,13 @@ const MOCK_NEWS: Record<string, NewsItem[]> = {
 export function HEORDashboard({ selectedCategories, sessionId }: DashboardProps) {
   const { newsData, loading, error, fetchPersonalizedNews } = useNewsAgents();
   const [lastUpdated, setLastUpdated] = useState<Date>(new Date());
+  const [chatModalOpen, setChatModalOpen] = useState(false);
+  const [selectedCategoryForChat, setSelectedCategoryForChat] = useState<{
+    category: string;
+    categoryName: string;
+    categoryIcon: string;
+    categoryColor: string;
+  } | null>(null);
 
   useEffect(() => {
     if (selectedCategories.length > 0 && sessionId) {
@@ -201,6 +209,19 @@ export function HEORDashboard({ selectedCategories, sessionId }: DashboardProps)
 
   const handleNewSession = () => {
     window.location.reload();
+  };
+
+  const handleOpenChat = (categoryId: string) => {
+    const config = CATEGORY_CONFIGS[categoryId as keyof typeof CATEGORY_CONFIGS];
+    if (config) {
+      setSelectedCategoryForChat({
+        category: categoryId,
+        categoryName: config.name,
+        categoryIcon: config.icon,
+        categoryColor: config.iconColor
+      });
+      setChatModalOpen(true);
+    }
   };
 
   return (
@@ -351,12 +372,23 @@ export function HEORDashboard({ selectedCategories, sessionId }: DashboardProps)
                       </div>
                     </CardTitle>
                     
-                    {newsItems.some(item => item.is_new) && (
-                      <Badge className={`${config.badgeColor} border-0`}>
-                        <i className="fas fa-star mr-1"></i>
-                        New Updates
-                      </Badge>
-                    )}
+                    <div className="flex items-center space-x-2">
+                      {newsItems.some(item => item.is_new) && (
+                        <Badge className={`${config.badgeColor} border-0`}>
+                          <i className="fas fa-star mr-1"></i>
+                          New Updates
+                        </Badge>
+                      )}
+                      <Button
+                        onClick={() => handleOpenChat(categoryId)}
+                        variant="outline"
+                        size="sm"
+                        className="hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                      >
+                        <i className="fas fa-comments mr-2"></i>
+                        Chat
+                      </Button>
+                    </div>
                   </div>
                 </CardHeader>
 
@@ -443,6 +475,22 @@ export function HEORDashboard({ selectedCategories, sessionId }: DashboardProps)
           </Card>
         )}
       </main>
+
+      {/* Category Chat Modal */}
+      {selectedCategoryForChat && (
+        <CategoryChatModal
+          isOpen={chatModalOpen}
+          onClose={() => {
+            setChatModalOpen(false);
+            setSelectedCategoryForChat(null);
+          }}
+          category={selectedCategoryForChat.category}
+          categoryName={selectedCategoryForChat.categoryName}
+          categoryIcon={selectedCategoryForChat.categoryIcon}
+          categoryColor={selectedCategoryForChat.categoryColor}
+          sessionId={sessionId}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/hooks/useNewsAgents.ts
+++ b/client/src/hooks/useNewsAgents.ts
@@ -36,6 +36,7 @@ export interface UseNewsAgentsReturn {
   fetchNews: (preferences: UserPreferences) => Promise<void>;
   fetchPersonalizedNews: (sessionId: string) => Promise<void>;
   fetchCategoryNews: (category: string, preferences: UserPreferences) => Promise<NewsItem[]>;
+  sendCategoryChat: (category: string, message: string, sessionId: string) => Promise<any>;
 }
 
 export const useNewsAgents = (): UseNewsAgentsReturn => {
@@ -120,6 +121,35 @@ export const useNewsAgents = (): UseNewsAgentsReturn => {
     }
   }, []);
 
+  const sendCategoryChat = useCallback(async (
+    category: string,
+    message: string,
+    sessionId: string
+  ): Promise<any> => {
+    try {
+      const response = await fetch(`/api/chat/category/${category}/send`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          session_id: sessionId,
+          message: message
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data;
+    } catch (err) {
+      console.error(`Error sending category chat:`, err);
+      throw err;
+    }
+  }, []);
+
   return {
     newsData,
     loading,
@@ -127,5 +157,6 @@ export const useNewsAgents = (): UseNewsAgentsReturn => {
     fetchNews,
     fetchPersonalizedNews,
     fetchCategoryNews,
+    sendCategoryChat,
   };
 };

--- a/server/controllers/category_chat_controller.py
+++ b/server/controllers/category_chat_controller.py
@@ -1,0 +1,91 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+from typing import Dict, Any, List
+
+from database import get_db
+from services.category_chat_agents import ChatAgentOrchestrator
+
+router = APIRouter()
+
+
+class CategoryChatRequest(BaseModel):
+    session_id: str
+    message: str
+
+
+class CategoryChatResponse(BaseModel):
+    success: bool
+    response: str
+    news_items: List[Dict[str, Any]]
+    queries_used: List[str]
+    error: str = None
+
+
+@router.post("/api/chat/category/{category}/send", response_model=CategoryChatResponse)
+async def send_category_chat(
+    category: str,
+    request: CategoryChatRequest,
+    db: Session = Depends(get_db)
+):
+    """Handle category-specific chat requests"""
+    
+    # Validate category
+    valid_categories = ["regulatory", "clinical", "market", "rwe"]
+    if category not in valid_categories:
+        raise HTTPException(status_code=400, detail=f"Invalid category. Must be one of: {valid_categories}")
+    
+    try:
+        # Initialize chat orchestrator
+        orchestrator = ChatAgentOrchestrator()
+        
+        # Handle the chat request
+        result = await orchestrator.handle_category_chat(
+            category=category,
+            user_message=request.message,
+            session_id=request.session_id,
+            db=db
+        )
+        
+        # Convert news items to dict format for JSON serialization
+        news_items_dict = []
+        for item in result.get("news_items", []):
+            news_items_dict.append({
+                "id": item.id,
+                "title": item.title,
+                "snippet": item.snippet,
+                "source": item.source,
+                "date": item.date,
+                "category": item.category,
+                "url": item.url,
+                "relevance_score": item.relevance_score,
+                "is_new": item.is_new
+            })
+        
+        return CategoryChatResponse(
+            success=result.get("success", False),
+            response=result.get("response", ""),
+            news_items=news_items_dict,
+            queries_used=result.get("queries_used", []),
+            error=result.get("error")
+        )
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Chat processing error: {str(e)}")
+
+
+@router.get("/api/chat/category/{category}/messages/{session_id}")
+async def get_category_chat_messages(
+    category: str,
+    session_id: str,
+    db: Session = Depends(get_db)
+):
+    """Get chat message history for a specific category (placeholder for future implementation)"""
+    
+    # For now, return empty history - this can be extended later
+    return {
+        "success": True,
+        "messages": [],
+        "category": category,
+        "session_id": session_id
+    }

--- a/server/main.py
+++ b/server/main.py
@@ -7,7 +7,7 @@ import uvicorn
 import os
 from config import settings
 from database import engine, Base
-from controllers import chat_controller, user_controller, news_controller
+from controllers import chat_controller, user_controller, news_controller, category_chat_controller
 
 # Create tables
 Base.metadata.create_all(bind=engine)
@@ -27,6 +27,7 @@ app.add_middleware(
 app.include_router(chat_controller.router)
 app.include_router(user_controller.router)
 app.include_router(news_controller.router)
+app.include_router(category_chat_controller.router)
 
 # Health check endpoint
 @app.get("/api/health")

--- a/server/services/category_chat_agents.py
+++ b/server/services/category_chat_agents.py
@@ -179,9 +179,9 @@ class CategoryChatAgent:
             category = category_mapping.get(self.category, "regulatory")
             
             # Create a temporary state for the existing agent
-            temp_state = self.existing_agents._create_agent_state(
+            temp_state = AgentState(
                 user_preferences=chat_enhanced_preferences,
-                category=category
+                category=self.existing_agents._get_category_enum(category)
             )
             
             # Override the search queries with our dynamic ones
@@ -223,9 +223,9 @@ class CategoryChatAgent:
             category = category_mapping.get(self.category, "regulatory")
             
             # Create temporary state for filtering
-            temp_state = self.existing_agents._create_agent_state(
+            temp_state = AgentState(
                 user_preferences=state.user_preferences,
-                category=category
+                category=self.existing_agents._get_category_enum(category)
             )
             temp_state.news_items = state.news_items
             

--- a/server/services/category_chat_agents.py
+++ b/server/services/category_chat_agents.py
@@ -1,0 +1,344 @@
+import asyncio
+import json
+from datetime import datetime, timedelta
+from typing import Dict, List, Any, Optional
+from dataclasses import dataclass
+from enum import Enum
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from langgraph.graph import StateGraph, END
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from config import settings
+from database import get_db, User
+from services.langgraph_agents import LangGraphNewsAgents, UserPreferences, NewsItem, AgentCategory
+
+
+class ChatAgentCategory(Enum):
+    REGULATORY_CHAT = "regulatory_chat"
+    CLINICAL_CHAT = "clinical_chat" 
+    MARKET_CHAT = "market_chat"
+    RWE_CHAT = "rwe_chat"
+
+
+@dataclass
+class ChatContext:
+    time_period: Optional[str] = None
+    specific_topics: List[str] = None
+    geographic_regions: List[str] = None
+    news_sources: List[str] = None
+    specific_requirements: List[str] = None
+    parsed_intent: Dict[str, Any] = None
+
+
+class ChatAgentState(BaseModel):
+    user_preferences: UserPreferences
+    category: ChatAgentCategory
+    user_message: str
+    context: ChatContext
+    news_items: List[NewsItem] = []
+    search_queries: List[str] = []
+    processing_status: str = "pending"
+    error_message: Optional[str] = None
+    chat_response: str = ""
+
+
+class CategoryChatAgent:
+    def __init__(self, category: str):
+        self.category = category
+        self.llm = ChatOpenAI(
+            model="gpt-4o-mini",
+            temperature=0.3,
+            openai_api_key=settings.openai_api_key
+        )
+        # Reuse existing LangGraph agents for actual news fetching
+        self.existing_agents = LangGraphNewsAgents()
+        
+    def create_chat_workflow(self) -> StateGraph:
+        """Create a chat-specific workflow that builds on existing agents"""
+        workflow = StateGraph(ChatAgentState)
+        
+        # Chat-specific workflow nodes
+        workflow.add_node("parse_user_intent", self._parse_user_intent)
+        workflow.add_node("generate_dynamic_queries", self._generate_dynamic_queries)
+        workflow.add_node("search_with_context", self._search_with_context)
+        workflow.add_node("filter_and_rank", self._filter_and_rank)
+        workflow.add_node("generate_response", self._generate_response)
+        
+        # Linear workflow for chat
+        workflow.set_entry_point("parse_user_intent")
+        workflow.add_edge("parse_user_intent", "generate_dynamic_queries")
+        workflow.add_edge("generate_dynamic_queries", "search_with_context")
+        workflow.add_edge("search_with_context", "filter_and_rank")
+        workflow.add_edge("filter_and_rank", "generate_response")
+        workflow.add_edge("generate_response", END)
+        
+        return workflow.compile()
+
+    async def _parse_user_intent(self, state: ChatAgentState) -> ChatAgentState:
+        """Parse user's chat message to understand intent and requirements"""
+        prompt = f"""
+        Parse this user message for {self.category} news:
+        "{state.user_message}"
+        
+        Extract and return as JSON with these fields:
+        {{
+            "time_period": "recent/last week/last month/specific date range",
+            "specific_topics": ["list", "of", "specific", "topics", "drugs", "conditions"],
+            "geographic_regions": ["list", "of", "regions", "countries"],
+            "news_sources": ["preferred", "news", "sources"],
+            "specific_requirements": ["approvals", "trials", "recalls", "coverage", "etc"]
+        }}
+        
+        Be specific and extract all relevant information from the user's request.
+        """
+        
+        try:
+            response = await self.llm.ainvoke([SystemMessage(content=prompt)])
+            parsed_intent = json.loads(response.content)
+            
+            # Update context with parsed intent
+            state.context = ChatContext(
+                time_period=parsed_intent.get("time_period"),
+                specific_topics=parsed_intent.get("specific_topics", []),
+                geographic_regions=parsed_intent.get("geographic_regions", []),
+                news_sources=parsed_intent.get("news_sources", []),
+                specific_requirements=parsed_intent.get("specific_requirements", []),
+                parsed_intent=parsed_intent
+            )
+        except Exception as e:
+            # Fallback parsing
+            state.context = ChatContext(
+                time_period="recent",
+                specific_topics=[],
+                geographic_regions=[],
+                news_sources=[],
+                specific_requirements=[],
+                parsed_intent={"error": str(e)}
+            )
+        
+        return state
+
+    async def _generate_dynamic_queries(self, state: ChatAgentState) -> ChatAgentState:
+        """Generate search queries based on user's chat message and context"""
+        intent = state.context.parsed_intent or {}
+        
+        prompt = f"""
+        Generate 3-5 specific search queries for {self.category} news based on:
+        
+        User message: "{state.user_message}"
+        Time period: {intent.get('time_period', 'recent')}
+        Specific topics: {intent.get('specific_topics', [])}
+        Geographic regions: {intent.get('geographic_regions', [])}
+        Requirements: {intent.get('specific_requirements', [])}
+        User expertise: {state.user_preferences.expertise_areas}
+        
+        Create highly specific queries that match the user's exact request.
+        Focus on the category: {self.category}
+        
+        Return as JSON array of strings.
+        """
+        
+        try:
+            response = await self.llm.ainvoke([SystemMessage(content=prompt)])
+            queries = json.loads(response.content)
+            state.search_queries = queries if isinstance(queries, list) else [response.content]
+        except:
+            # Fallback queries
+            state.search_queries = [
+                f"{self.category} news {state.user_message}",
+                f"{self.category} updates {state.user_message}",
+                f"{self.category} latest {state.user_message}"
+            ]
+        
+        return state
+
+    async def _search_with_context(self, state: ChatAgentState) -> ChatAgentState:
+        """Search using the dynamic queries with context awareness"""
+        try:
+            # Create a modified user preferences object with chat context
+            chat_enhanced_preferences = UserPreferences(
+                expertise_areas=state.user_preferences.expertise_areas,
+                therapeutic_areas=state.user_preferences.therapeutic_areas,
+                regions=state.context.geographic_regions or state.user_preferences.regions,
+                keywords=state.context.specific_topics or state.user_preferences.keywords,
+                news_recency_days=7  # Default, could be adjusted based on time_period
+            )
+            
+            # Use existing agents but with our dynamic queries
+            # We'll override the query generation by directly calling search methods
+            category_mapping = {
+                "regulatory": "regulatory",
+                "clinical": "clinical", 
+                "market": "market",
+                "rwe": "rwe"
+            }
+            
+            category = category_mapping.get(self.category, "regulatory")
+            
+            # Create a temporary state for the existing agent
+            temp_state = self.existing_agents._create_agent_state(
+                user_preferences=chat_enhanced_preferences,
+                category=category
+            )
+            
+            # Override the search queries with our dynamic ones
+            temp_state.search_queries = state.search_queries
+            
+            # Use existing search methods but with our queries
+            if category == "regulatory":
+                temp_state = await self.existing_agents._search_regulatory_news(temp_state)
+            elif category == "clinical":
+                temp_state = await self.existing_agents._search_clinical_news(temp_state)
+            elif category == "market":
+                temp_state = await self.existing_agents._search_market_news(temp_state)
+            elif category == "rwe":
+                temp_state = await self.existing_agents._search_rwe_news(temp_state)
+            
+            # Transfer results to our chat state
+            state.news_items = temp_state.news_items
+            
+        except Exception as e:
+            state.error_message = f"Search error: {str(e)}"
+            state.news_items = []
+        
+        return state
+
+    async def _filter_and_rank(self, state: ChatAgentState) -> ChatAgentState:
+        """Filter and rank results based on chat context"""
+        if not state.news_items:
+            return state
+            
+        try:
+            # Use existing relevance filtering but with chat context
+            category_mapping = {
+                "regulatory": "regulatory",
+                "clinical": "clinical", 
+                "market": "market",
+                "rwe": "rwe"
+            }
+            
+            category = category_mapping.get(self.category, "regulatory")
+            
+            # Create temporary state for filtering
+            temp_state = self.existing_agents._create_agent_state(
+                user_preferences=state.user_preferences,
+                category=category
+            )
+            temp_state.news_items = state.news_items
+            
+            # Apply existing relevance filters
+            if category == "regulatory":
+                temp_state = await self.existing_agents._filter_regulatory_relevance(temp_state)
+            elif category == "clinical":
+                temp_state = await self.existing_agents._filter_clinical_relevance(temp_state)
+            elif category == "market":
+                temp_state = await self.existing_agents._filter_market_relevance(temp_state)
+            elif category == "rwe":
+                temp_state = await self.existing_agents._filter_rwe_relevance(temp_state)
+            
+            # Update with filtered results
+            state.news_items = temp_state.news_items
+            
+        except Exception as e:
+            state.error_message = f"Filtering error: {str(e)}"
+        
+        return state
+
+    async def _generate_response(self, state: ChatAgentState) -> ChatAgentState:
+        """Generate a natural language response to the user"""
+        intent = state.context.parsed_intent or {}
+        
+        prompt = f"""
+        Generate a helpful, conversational response to the user's request for {self.category} news.
+        
+        Original request: "{state.user_message}"
+        Parsed intent: {intent}
+        Found {len(state.news_items)} relevant news items
+        
+        Provide:
+        1. Acknowledge their specific request
+        2. Summarize what you found (number of items, key themes)
+        3. Highlight 2-3 most relevant findings
+        4. Offer to provide more specific results or different filters if needed
+        
+        Keep it conversational and helpful. If no results found, suggest alternative searches.
+        """
+        
+        try:
+            response = await self.llm.ainvoke([SystemMessage(content=prompt)])
+            state.chat_response = response.content
+        except Exception as e:
+            state.chat_response = f"I found {len(state.news_items)} relevant news items for your request. Please let me know if you'd like more specific information."
+        
+        return state
+
+
+class ChatAgentOrchestrator:
+    def __init__(self):
+        self.chat_agents = {
+            "regulatory": CategoryChatAgent("regulatory"),
+            "clinical": CategoryChatAgent("clinical"),
+            "market": CategoryChatAgent("market"),
+            "rwe": CategoryChatAgent("rwe")
+        }
+    
+    def _get_user_preferences_from_db(self, session_id: str, db: Session) -> UserPreferences:
+        """Fetch user preferences from database - reusing existing method"""
+        user = db.query(User).filter(User.session_id == session_id).first()
+        
+        if not user:
+            return UserPreferences(
+                expertise_areas=["health economics and market access"],
+                therapeutic_areas=["oncology", "cardiovascular", "diabetes"],
+                regions=["United States", "Europe"],
+                keywords=["FDA", "clinical trials", "market access"],
+                news_recency_days=7
+            )
+        
+        return UserPreferences(
+            expertise_areas=[user.preference_expertise] if user.preference_expertise else ["healthcare"],
+            therapeutic_areas=user.selected_categories or ["oncology"],
+            regions=["United States", "Europe"],  # Default regions
+            keywords=user.selected_categories or ["FDA"],
+            news_recency_days=7
+        )
+    
+    async def handle_category_chat(
+        self, 
+        category: str, 
+        user_message: str, 
+        session_id: str,
+        db: Session
+    ) -> Dict[str, Any]:
+        """Handle chat for a specific category"""
+        
+        # Get user preferences
+        user_preferences = self._get_user_preferences_from_db(session_id, db)
+        
+        # Create chat state
+        state = ChatAgentState(
+            user_preferences=user_preferences,
+            category=getattr(ChatAgentCategory, f"{category.upper()}_CHAT"),
+            user_message=user_message,
+            context=ChatContext()
+        )
+        
+        # Run the chat agent
+        agent = self.chat_agents[category]
+        workflow = agent.create_chat_workflow()
+        result = await workflow.ainvoke(state)
+        
+        return {
+            "success": True,
+            "response": result.chat_response,
+            "news_items": result.news_items,
+            "queries_used": result.search_queries,
+            "error": result.error_message
+        }
+    
+    async def close(self):
+        """Clean up resources"""
+        await self.chat_agents["regulatory"].existing_agents.close()


### PR DESCRIPTION
Add category-specific chat functionality to allow users to refine news searches within each category.

This PR introduces a chat interface for each news category, enabling users to ask specific questions (e.g., "Show me recent FDA approvals for oncology drugs") and dynamically fetch relevant news. The implementation builds new frontend components, a dedicated backend API, and a new LangGraph agent architecture that reuses existing news fetching capabilities without modifying any current functionalities.

---

[Open in Web](https://www.cursor.com/agents?id=bc-c0ef81b7-0578-4f94-89a3-43e8db96159c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c0ef81b7-0578-4f94-89a3-43e8db96159c)