### PR TITLE
Implement email auth and update chat flow

### DIFF
--- a/server/alembic.ini
+++ b/server/alembic.ini
@@ -1,0 +1,101 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = migrations
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python-dateutil library that can be
+# installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version number format
+version_num_format = %04d
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses
+# os.pathsep. If this key is omitted entirely, it falls back to the legacy
+# behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+version_path_separator = os
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = postgresql://user:password@localhost/heor_signal
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/server/migrations/add_user_auth_columns.py
+++ b/server/migrations/add_user_auth_columns.py
@@ -1,0 +1,38 @@
+"""Add authentication columns to users table
+
+Revision ID: add_user_auth_columns
+Revises: 
+Create Date: 2025-01-27 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'add_user_auth_columns'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add new columns for authentication
+    op.add_column('users', sa.Column('name', sa.String(), nullable=True))
+    op.add_column('users', sa.Column('email', sa.String(), nullable=True))
+    op.add_column('users', sa.Column('password_hash', sa.String(), nullable=True))
+    
+    # Create indexes for performance
+    op.create_index(op.f('ix_users_email'), 'users', ['email'], unique=True)
+    op.create_index(op.f('ix_users_name'), 'users', ['name'], unique=False)
+
+
+def downgrade():
+    # Remove indexes
+    op.drop_index(op.f('ix_users_name'), table_name='users')
+    op.drop_index(op.f('ix_users_email'), table_name='users')
+    
+    # Remove columns
+    op.drop_column('users', 'password_hash')
+    op.drop_column('users', 'email')
+    op.drop_column('users', 'name')

--- a/server/migrations/env.py
+++ b/server/migrations/env.py
@@ -1,0 +1,91 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+from alembic import context
+import os
+import sys
+
+# Add the parent directory to the path so we can import our models
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from database import Base
+from models.user import User
+from models.chat import Chat
+from models.thread import Thread
+from config import settings
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def get_url():
+    return settings.database_url
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    configuration = config.get_section(config.config_ini_section)
+    configuration["sqlalchemy.url"] = get_url()
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/server/migrations/script.py.mako
+++ b/server/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/server/run_migration.py
+++ b/server/run_migration.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Simple script to add authentication columns to the users table
+"""
+import os
+import sys
+from sqlalchemy import create_engine, text
+from config import settings
+
+def run_migration():
+    """Add authentication columns to users table"""
+    engine = create_engine(settings.database_url)
+    
+    with engine.connect() as conn:
+        # Add the new columns
+        conn.execute(text("""
+            ALTER TABLE users 
+            ADD COLUMN IF NOT EXISTS name VARCHAR,
+            ADD COLUMN IF NOT EXISTS email VARCHAR,
+            ADD COLUMN IF NOT EXISTS password_hash VARCHAR
+        """))
+        
+        # Create indexes
+        conn.execute(text("""
+            CREATE INDEX IF NOT EXISTS ix_users_email ON users(email)
+        """))
+        
+        conn.execute(text("""
+            CREATE INDEX IF NOT EXISTS ix_users_name ON users(name)
+        """))
+        
+        # Make email unique
+        conn.execute(text("""
+            ALTER TABLE users 
+            ADD CONSTRAINT IF NOT EXISTS users_email_unique UNIQUE (email)
+        """))
+        
+        conn.commit()
+        print("Migration completed successfully!")
+
+if __name__ == "__main__":
+    run_migration()


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement email-based user registration and update the 'Let's Chat' onboarding flow.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR transitions the user authentication system from session-based to email-based. The "Let's Chat" button on the dashboard now directs new users to a registration page before proceeding to the chat interface. Includes a migration script to add `name`, `email`, and `password_hash` columns to the `users` table.

---

[Open in Web](https://cursor.com/agents?id=bc-9ab5f84a-801b-4d99-be5c-81dd61048f7b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9ab5f84a-801b-4d99-be5c-81dd61048f7b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)