### PR TITLE
Implement email auth and update chat flow

### DIFF
--- a/client/src/components/chat/simple-chat-interface.tsx
+++ b/client/src/components/chat/simple-chat-interface.tsx
@@ -68,17 +68,20 @@ export function SimpleChatInterface({ sessionId, userStatus, onStartChat, hasSta
     }
   };
 
-  // Handler for new chat - reset onboarding status
+  // Handler for new chat - create fresh chat session
   const handleNewChat = async () => {
     try {
-      // Call API to reset onboarding status
-      const response = await apiRequest('POST', '/api/user/reset-onboarding', {
+      // Show loading screen
+      setShowInitialLoader(true);
+      
+      // Call API to create new chat session
+      const response = await apiRequest('POST', '/api/user/new-chat', {
         session_id: sessionId
       });
       
       if (response.ok) {
         const data = await response.json();
-        console.log('Onboarding reset successfully:', data);
+        console.log('New chat created successfully:', data);
         
         // Reset local state
         setMessages([]);
@@ -87,18 +90,20 @@ export function SimpleChatInterface({ sessionId, userStatus, onStartChat, hasSta
         setInputMessage("");
         setSelectedCategories([]);
         
-        // Scroll to top
-        if (messagesEndRef.current) {
-          messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
-        }
-        
         // Invalidate user status query to refetch updated data
         window.dispatchEvent(new CustomEvent('refresh-user-status'));
+        
+        // Hide loading screen after a short delay
+        setTimeout(() => {
+          setShowInitialLoader(false);
+        }, 1000);
       } else {
-        console.error('Failed to reset onboarding');
+        console.error('Failed to create new chat');
+        setShowInitialLoader(false);
       }
     } catch (error) {
-      console.error('Error resetting onboarding:', error);
+      console.error('Error creating new chat:', error);
+      setShowInitialLoader(false);
     }
   };
 

--- a/client/src/components/dashboard/heor-dashboard.tsx
+++ b/client/src/components/dashboard/heor-dashboard.tsx
@@ -204,23 +204,23 @@ export function HEORDashboard({ selectedCategories, sessionId }: DashboardProps)
 
   const handleNewChat = async () => {
     try {
-      // Call API to reset onboarding status
-      const response = await apiRequest('POST', '/api/user/reset-onboarding', {
+      // Call API to create new chat session
+      const response = await apiRequest('POST', '/api/user/new-chat', {
         session_id: sessionId
       });
       
       if (response.ok) {
         const data = await response.json();
-        console.log('Onboarding reset successfully:', data);
+        console.log('New chat created successfully:', data);
         
         // Navigate back to chat interface for the current user
         // Use window.location.replace to avoid adding to browser history
         window.location.replace(window.location.origin);
       } else {
-        console.error('Failed to reset onboarding');
+        console.error('Failed to create new chat');
       }
     } catch (error) {
-      console.error('Error resetting onboarding:', error);
+      console.error('Error creating new chat:', error);
     }
   };
 

--- a/client/src/pages/onboarding.tsx
+++ b/client/src/pages/onboarding.tsx
@@ -229,6 +229,11 @@ export default function Onboarding() {
     return <LoadingScreen message={loadingMessage} />;
   }
 
+  // Show loading screen for new chat creation
+  if (showInitialLoader && !hasStartedChat) {
+    return <LoadingScreen message="Initializing your assistant..." />;
+  }
+
   if (initUserMutation.error) {
     console.error('Init mutation error:', initUserMutation.error);
     return (

--- a/server/controllers/user_controller.py
+++ b/server/controllers/user_controller.py
@@ -61,12 +61,12 @@ async def initialize_user(
                 detail=f"Error initializing user: {str(e)}"
             )
 
-@router.post("/reset-onboarding", response_model=Dict[str, Any])
-async def reset_user_onboarding(
+@router.post("/new-chat", response_model=Dict[str, Any])
+async def create_new_chat(
     request: ResetOnboardingRequest,
     db: Session = Depends(get_db)
 ):
-    """Reset user onboarding status for new chat"""
+    """Create a new chat session for the user"""
     max_retries = 3
     retry_delay = 1  # seconds
     
@@ -80,8 +80,8 @@ async def reset_user_onboarding(
                     detail="User not found"
                 )
             
-            # Reset onboarding status
-            user = await user_service.reset_onboarding(db, user.id)
+            # Create new chat session
+            user = await user_service.create_new_chat(db, user.id)
             
             return {
                 "success": True,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor "New Session" to "New Chat" functionality to create a fresh chat thread for the current user and update loading messages.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, "New Session" either created a new user entry or only reset the frontend onboarding state. This PR ensures that clicking "New Chat" (renamed from "New Session") for a logged-in user creates a completely new OpenAI chat thread, providing a fresh conversation experience without creating new user records. It also updates the loading screen to reflect this action.

---

[Open in Web](https://cursor.com/agents?id=bc-9ab5f84a-801b-4d99-be5c-81dd61048f7b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9ab5f84a-801b-4d99-be5c-81dd61048f7b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)